### PR TITLE
Fix creating directory

### DIFF
--- a/Makefile.doom
+++ b/Makefile.doom
@@ -75,6 +75,7 @@ $(BIN): $(LINKOBJ)
 	$(LINK) $(LINKOBJ) -o "release/doom.elf" $(LIBS)
 
 obj/deh_str.o: $(GLOBALDEPS) src/deh_str.c
+	@mkdir -p obj 
 	$(CC) -c src/deh_str.c -o obj/deh_str.o $(CFLAGS)
 	
 obj/d_event.o: $(GLOBALDEPS) src/d_event.c

--- a/Makefile.heretic
+++ b/Makefile.heretic
@@ -72,6 +72,7 @@ $(BIN): $(LINKOBJ)
 	$(LINK) $(LINKOBJ) -o "release/heretic.elf" $(LIBS)
 
 obj/deh_str.o: $(GLOBALDEPS) src/deh_str.c
+	@mkdir -p obj 
 	$(CC) -c src/deh_str.c -o obj/deh_str.o $(CFLAGS)
 	
 obj/d_event.o: $(GLOBALDEPS) src/d_event.c


### PR DESCRIPTION
Using WSL1.
By default I'm getting an error
```
aarch64-none-elf-gcc -c src/deh_str.c -o obj/deh_str.o -Isrc -Icodeblocks -Iopl -Itextscreen -I/opt/devkitpro/portlibs/switch/include/SDL2 -I"src/main" -I/opt/devkitpro/libnx/include -I/opt/devkitpro/portlibs/switch/include       -fsigned-char -march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIE -fomit-frame-pointer -O2 -DSWITCH
Assembler messages:
Fatal error: can't create obj/deh_str.o: No such file or directory
makefile.doom:77: recipe for target 'obj/deh_str.o' failed
make: *** [obj/deh_str.o] Error 1
```

This PR solves issue by using `mkdir` to create directory with `-p` to not fail if directory exists.

If this PR will be accepted, I would like it to be labeled with text 
```
hacktoberfest-accepted
```